### PR TITLE
Add macOS ignores to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,19 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+# macOS Ignores
+*.DS_Store
+.AppleDouble
+.LSOverride
+.swp
+
+# Thumbnails
+._*
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk


### PR DESCRIPTION
Taken from https://github.com/github/gitignore/blob/master/Global/macOS.gitignore. `.swp` is vim backup file. 